### PR TITLE
fix next auth dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
-    "@eslint/eslintrc": "^3",
-    "@types/next-auth": "^4.17.8"
+    "@eslint/eslintrc": "^3"
   }
 }


### PR DESCRIPTION
## Summary
- remove nonexistent `@types/next-auth` dev dependency

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@eslint%2feslintrc)*
- `npm run dev` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b5f2c3b188324b7e31b32bfbd8cbc