### PR TITLE
Add MongoDB jobs page and upload persistence

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,3 @@
 DATABASE_URL="file:./dev.db"
+MONGODB_URI=""
+MONGODB_DB_NAME="jobsdb"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "next-auth": "^4.24.7",
     "prisma": "^6.14.0",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "mongodb": "^6.5.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,5 +1,6 @@
 // src/app/api/upload/route.ts
 import { NextRequest, NextResponse } from "next/server";
+import { getUserDocumentsCollection } from "@/lib/mongodb";
 
 export const runtime = "nodejs";
 const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:5000/upload";
@@ -22,11 +23,29 @@ export async function POST(req: NextRequest) {
     });
 
     const data = await res.json();
-    return NextResponse.json(data, { status: res.status });
-  } catch (e: any) {
-    return NextResponse.json(
-      { error: e?.message || "Proxy error" },
+
+    if (res.ok) {
+      try {
+        const docs = await getUserDocumentsCollection();
+        const userId = req.nextUrl.searchParams.get("userId") || "anonymous";
+        await docs.insertOne({
+          userId,
+          filename: file.name,
+          text: data.text,
+          meta: data.meta,
+          warnings: data.warnings,
+          uploadedAt: new Date(),
+        });
+      } catch (err) {
+        console.error("Mongo insert error", err);
+      }
+    }
+
+      return NextResponse.json(data, { status: res.status });
+    } catch (e: unknown) {
+      return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Proxy error" },
       { status: 500 }
-    );
-  }
+      );
+    }
 }

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -1,0 +1,26 @@
+import { getJobsCollection } from '@/lib/mongodb';
+
+type Job = {
+  _id: { toString(): string };
+  title: string;
+  company?: string;
+};
+
+export default async function JobsPage() {
+  const collection = await getJobsCollection();
+  const jobs = (await collection.find().toArray()) as Job[];
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Job Listings</h1>
+      <ul className="space-y-2">
+        {jobs.map((job: Job) => (
+          <li key={job._id.toString()} className="border rounded p-4">
+            <h2 className="font-semibold">{job.title}</h2>
+            {job.company && <p>{job.company}</p>}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -1,0 +1,26 @@
+import { MongoClient } from 'mongodb';
+
+const uri = process.env.MONGODB_URI || '';
+let client: MongoClient | null = null;
+
+async function getClient() {
+  if (!uri) {
+    throw new Error('MONGODB_URI is not set');
+  }
+  if (client) return client;
+  client = new MongoClient(uri);
+  await client.connect();
+  return client;
+}
+
+export async function getJobsCollection() {
+  const dbName = process.env.MONGODB_DB_NAME || 'jobsdb';
+  const db = (await getClient()).db(dbName);
+  return db.collection('jobs');
+}
+
+export async function getUserDocumentsCollection() {
+  const dbName = process.env.MONGODB_DB_NAME || 'jobsdb';
+  const db = (await getClient()).db(dbName);
+  return db.collection('user_documents');
+}

--- a/types/mongodb.d.ts
+++ b/types/mongodb.d.ts
@@ -1,0 +1,1 @@
+declare module 'mongodb';


### PR DESCRIPTION
## Summary
- add MongoDB helper and stub types
- create jobs page that reads listings from MongoDB
- persist uploaded document metadata to MongoDB

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac6743dd3c83248e47f0cac747f5b3