### PR TITLE
feat: integrate MongoDB user storage

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 DATABASE_URL="file:./dev.db"
+MONGODB_URI="mongodb+srv://abainscp:5lqehWwGMlmkG7Ct@cluster0.dpdaxlz.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0"

--- a/.env.local
+++ b/.env.local
@@ -4,3 +4,4 @@ AUTH_SECRET=generate_with_openssl
 AUTH_URL=http://localhost:3000
 
 BACKEND_URL=http://localhost:5000/upload
+MONGODB_URI="mongodb+srv://abainscp:5lqehWwGMlmkG7Ct@cluster0.dpdaxlz.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@prisma/client": "^6.14.0",
     "next": "15.4.6",
     "next-auth": "^4.24.7",
+    "mongodb": "^6.5.0",
     "prisma": "^6.14.0",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -23,10 +23,8 @@ export async function POST(req: NextRequest) {
 
     const data = await res.json();
     return NextResponse.json(data, { status: res.status });
-  } catch (e: any) {
-    return NextResponse.json(
-      { error: e?.message || "Proxy error" },
-      { status: 500 }
-    );
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "Proxy error";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,7 @@ import { PrismaAdapter } from "@auth/prisma-adapter";
 import { NextAuthOptions } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
 import { prisma } from "@/lib/prisma";
+import { getUserDb } from "@/lib/mongodb";
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
@@ -12,4 +13,19 @@ export const authOptions: NextAuthOptions = {
       clientSecret: process.env.AUTH_GOOGLE_SECRET!,
     }),
   ],
+  callbacks: {
+    async signIn({ user }) {
+      const db = await getUserDb();
+      const users = db.collection("users");
+      const existing = await users.findOne({ email: user.email });
+      if (!existing) {
+        await users.insertOne({
+          email: user.email,
+          name: user.name,
+          image: user.image,
+        });
+      }
+      return true;
+    },
+  },
 };

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -1,0 +1,37 @@
+// src/lib/mongodb.ts
+import type { Db, MongoClient } from "mongodb";
+
+const uri = process.env.MONGODB_URI;
+if (!uri) {
+  throw new Error("Missing environment variable MONGODB_URI");
+}
+
+let client: MongoClient | null = null;
+let clientPromise: Promise<MongoClient>;
+
+if (process.env.NODE_ENV === "development") {
+  const globalWithMongo = globalThis as typeof globalThis & {
+    _mongoClientPromise?: Promise<MongoClient>;
+  };
+  if (!globalWithMongo._mongoClientPromise) {
+    client = new MongoClient(uri);
+    globalWithMongo._mongoClientPromise = client.connect();
+  }
+  clientPromise = globalWithMongo._mongoClientPromise;
+} else {
+  client = new MongoClient(uri);
+  clientPromise = client.connect();
+}
+
+export default clientPromise;
+
+export const getJobsDb = async (): Promise<Db> => {
+  const conn = await clientPromise;
+  return conn.db("jobsdb");
+};
+
+export const getUserDb = async (): Promise<Db> => {
+  const conn = await clientPromise;
+  return conn.db("user");
+};
+


### PR DESCRIPTION
## Summary
- configure NextAuth to save Google login users into MongoDB `user` database
- add MongoDB client helper for `jobsdb` and user databases
- fix upload API error handling and expose MONGODB_URI env

## Testing
- `npm run lint`
- `npm install mongodb` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6e9ad20083248d8f2440689cdd56